### PR TITLE
overlay: Disable voice affordance on lockscreen

### DIFF
--- a/overlay/common/frameworks/base/packages/SystemUI/res/values/config.xml
+++ b/overlay/common/frameworks/base/packages/SystemUI/res/values/config.xml
@@ -18,10 +18,13 @@
 <!-- These resources are around just to allow their values to be customized
      for different hardware and product builds. -->
 <resources>
-<!-- Control whether status bar should distinguish HSPA data icon
-     from UMTS data icon on devices -->
+    <!-- Control whether status bar should distinguish HSPA data icon
+         from UMTS data icon on devices -->
     <bool name="config_hspa_data_distinguishable">true</bool>
 
-<!-- Should "4G" be shown instead of "LTE" when the network is NETWORK_TYPE_LTE? -->
+    <!-- Should "4G" be shown instead of "LTE" when the network is NETWORK_TYPE_LTE? -->
     <bool name="config_show4GForLTE">false</bool>
+
+    <!-- Show voice affordance on Keyguard -->
+    <bool name="config_keyguardShowVoiceAffordance">false</bool>
 </resources>


### PR DESCRIPTION
* If Google App is installed, the dialer icon on the left lockscreen shortcut
  gets remapped to open the voice input action of Google App. Very few
  (probably nobody) uses that, so let's retain our sane default of phone.

Change-Id: Iaa581558b709e3ee6a66bb72f72e9ab3991dafa1